### PR TITLE
ugwp_driver_v0.f compilation warning fix

### DIFF
--- a/gfsphysics/physics/ugwp_driver_v0.f
+++ b/gfsphysics/physics/ugwp_driver_v0.f
@@ -1991,8 +1991,8 @@
         Km(1:levs) = ksum(1:levs) * rho(1:levs)* rho(1:levs)
  
         do j=1, nstab
-          call diff_1d_wtend(levs, dtstab, Fw, Fw1, levs,
-     &                       del(i,:), Sw, Sw1)
+          call diff_1d_wtend(levs, dtstab, Fw, Fw1, Km,
+     &                       rdp, rdpm, Sw, Sw1)
           Fw  = Sw
           Fw1 = Sw1
         enddo
@@ -2004,7 +2004,7 @@
         Kpt = Km*iPr_pt
         Fw(1:levs) =  pdTdt(i, 1:levs)*Ptmap(1:levs)
         do j=1, nstab
-          call diff_1d_ptend(levs, dtstab, Fw, Kpt, del(i,:), Sw)
+          call diff_1d_ptend(levs, dtstab, Fw, Kpt, rdp, rdpm, Sw)
           Fw  = Sw
         enddo
          ed_dtdt(i,1:levs) = Sw(1:levs)/Ptmap(1:levs)


### PR DESCRIPTION
fix compilation warnings related to wrong arguments passed into 2 subroutines in ugwp_driver_v0.f (note that the code that generated the warnings is in a non-active section)

Associated PR: https://github.com/NCAR/ccpp-physics/pull/354