### PR TITLE
fix array dimensions for phii, prsi in ugwp_driver_v0.F

### DIFF
--- a/gfsphysics/GFS_layer/GFS_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_driver.F90
@@ -460,7 +460,7 @@ module GFS_driver
       call cires_ugwp_init(Model%me,      Model%master, Model%nlunit,  Init_parm%logunit, &
                            Model%fn_nml,  Model%lonr,   Model%latr,    Model%levs,        &
                            Init_parm%ak,  Init_parm%bk, p_ref,         Model%dtp,         &
-                           Model%cdmbgwd, Model%cgwf,   Model%prslrd0, Model%ral_ts)
+                           Model%cdmbgwd(1:2), Model%cgwf,   Model%prslrd0, Model%ral_ts)
     endif
 #endif
 

--- a/gfsphysics/physics/ugwp_driver_v0.f
+++ b/gfsphysics/physics/ugwp_driver_v0.f
@@ -46,7 +46,9 @@
      &,                            rain
 
        real(kind=kind_phys), intent(in), dimension(im,levs) :: ugrs
-     &,        vgrs, tgrs, qgrs, prsi, prsl, prslk, phii, phil, del
+     &,        vgrs, tgrs, qgrs, prsl, prslk, phil, del
+       real(kind=kind_phys), intent(in), dimension(im,levs+1) :: 
+     &         phii, prsi
 
 !      real(kind=kind_phys), intent(in) :: oro_stat(im,nmtvr)
        real(kind=kind_phys), intent(in), dimension(im) :: hprime, oc


### PR DESCRIPTION
This is an emergency bugfix found by Valery Yudin, communicated through email to @grantfirl.

Associated PR:
https://github.com/NCAR/ccpp-physics/pull/368