### PR TITLE
change suite_FV3_GFS_v15.2 to suite_FV3_GFS_v15p2

### DIFF
--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15p2" lib="ccppphys" ver="3">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">


### PR DESCRIPTION
One cannot have the period character in the name of a suite because it gets translated into Fortran cap subroutine names. Followup to https://github.com/NCAR/gmtb-scm/pull/154