### PR TITLE
dtc/develop: speed up static compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
 	branch = dtc/develop
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = dtc/develop
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = avoid_recompile_without_change
+	url = https://github.com/NCAR/ccpp-framework
+	branch = dtc/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = dtc/develop
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = avoid_recompile_without_change
+	url = https://github.com/NCAR/ccpp-physics
+	branch = dtc/develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
 	branch = dtc/develop
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = dtc/develop
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = dtc/develop
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = avoid_recompile_without_change
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = dtc/develop
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = dtc/develop
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = avoid_recompile_without_change


### PR DESCRIPTION
WORK IN PROGRESS

- update `.gitmodules` and submodule pointer for ccpp-framework for code review and testing

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/277
https://github.com/NCAR/ccpp-physics/pull/425
https://github.com/NCAR/fv3atm/pull/35
https://github.com/NCAR/ufs-weather-model/pull/33

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/33.