### PR TITLE
dtc/hwrf-physics: HWRF Ferrier-Aligo MP scheme updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = dtc/hwrf-physics
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = HAFS_fer_hires_for_dtc_hwrf-physics
+	url = https://github.com/NCAR/ccpp-physics
+	branch = dtc/hwrf-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+	url = https://github.com/NCAR/GFDL_atmos_cubed_sphere
+	branch = dtc/develop
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework
-	branch = master
+	branch = dtc/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	#url = https://github.com/NCAR/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = dtc/hwrf-physics
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = dtc/hwrf-physics
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = HAFS_fer_hires_for_dtc_hwrf-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NCAR/GFDL_atmos_cubed_sphere
-	branch = dtc/develop
+	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework
-	branch = dtc/develop
+	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	#url = https://github.com/NCAR/ccpp-physics

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -339,6 +339,7 @@ OPTIONAL_ARGUMENTS = {
             'rime_factor',
             ],
         },
+
     #'subroutine_name_1' : 'all',
     #'subroutine_name_2' : 'none',
     #'subroutine_name_2' : [ 'var1', 'var3'],

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -339,7 +339,6 @@ OPTIONAL_ARGUMENTS = {
             'rime_factor',
             ],
         },
-
     #'subroutine_name_1' : 'all',
     #'subroutine_name_2' : 'none',
     #'subroutine_name_2' : [ 'var1', 'var3'],

--- a/ccpp/suites/suite_FV3_HAFS_ferhires.xml
+++ b/ccpp/suites/suite_FV3_HAFS_ferhires.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_HAFS_ferhires_update_moist" lib="ccppphys" ver="3">
+<suite name="FV3_HAFS_ferhires" lib="ccppphys" ver="3">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">


### PR DESCRIPTION
This PR contains https://github.com/NCAR/fv3atm/pull/28, but updated for the dtc/hwrf-physics branch.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/435
https://github.com/NCAR/fv3atm/pull/43
https://github.com/NCAR/ufs-weather-model/pull/41

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/41.