### PR TITLE
Omit UGWP in HAFS SDF file following HAFS practice

### DIFF
--- a/ccpp/suites/suite_FV3_HAFS_ferhires.xml
+++ b/ccpp/suites/suite_FV3_HAFS_ferhires.xml
@@ -55,10 +55,6 @@
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
-      <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
-      <scheme>GFS_GWD_generic_post</scheme>
       <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>

--- a/gfsphysics/CCPP_layer/CCPP_typedefs.F90
+++ b/gfsphysics/CCPP_layer/CCPP_typedefs.F90
@@ -60,6 +60,7 @@ module CCPP_typedefs
      real(kind_dyn),  pointer            :: qr(:,:,:)
      real(kind_dyn),  pointer            :: qs(:,:,:)
      real(kind_dyn),  pointer            :: qg(:,:,:)
+     real(kind_dyn),  pointer            :: qf(:,:,:)    ! HWRF
      real(kind_dyn),  pointer            :: qc(:,:,:)
      real(kind_dyn),  pointer            :: q_con(:,:,:)
      integer                             :: nthreads
@@ -86,10 +87,10 @@ contains
 !-----------------------------
   subroutine interstitial_create (Interstitial, is, ie, isd, ied, js, je, jsd, jed, npz, ng, &
                                   dt_atmos, p_split, k_split, zvir, p_ref, ak, bk,           &
-                                  do_ql, do_qi, do_qr, do_qs, do_qg, do_qa,                  &
+                                  do_ql, do_qi, do_qr, do_qs, do_qg, do_qf, do_qa,           &
                                   kappa, hydrostatic, do_sat_adj,                            &
                                   delp, delz, area, peln, phis, pkz, pt,                     &
-                                  qvi, qv, ql, qi, qr, qs, qg, qc, q_con,                    &
+                                  qvi, qv, ql, qi, qr, qs, qg, qf, qc, q_con,                &
                                   nthreads, nwat, ngas, rilist, cpilist, mpirank, mpiroot)
     !
     implicit none
@@ -117,6 +118,7 @@ contains
     logical, intent(in) :: do_qr
     logical, intent(in) :: do_qs
     logical, intent(in) :: do_qg
+    logical, intent(in) :: do_qf   ! HWRF
     logical, intent(in) :: do_qa
     real(kind_dyn),    intent(in) :: kappa
     logical, intent(in) :: hydrostatic
@@ -135,6 +137,7 @@ contains
     real(kind_dyn),  target, intent(in) :: qr(:,:,:)
     real(kind_dyn),  target, intent(in) :: qs(:,:,:)
     real(kind_dyn),  target, intent(in) :: qg(:,:,:)
+    real(kind_dyn),  target, intent(in) :: qf(:,:,:)   ! HWRF
     real(kind_dyn),  target, intent(in) :: qc(:,:,:)
     real(kind_dyn),  target, intent(in) :: q_con(:,:,:)
     integer, intent(in) :: nthreads
@@ -205,6 +208,7 @@ contains
     if (do_qr) Interstitial%qr => qr
     if (do_qs) Interstitial%qs => qs
     if (do_qg) Interstitial%qg => qg
+    if (do_qf) Interstitial%qf => qf
     if (do_qa) Interstitial%qc => qc
 #ifdef USE_COND
     Interstitial%npzq_con = npz
@@ -347,6 +351,7 @@ contains
     if (associated(Interstitial%qr)) write (0,*) 'sum(Interstitial%qr)           = ', Interstitial%qr
     if (associated(Interstitial%qs)) write (0,*) 'sum(Interstitial%qs)           = ', Interstitial%qs
     if (associated(Interstitial%qg)) write (0,*) 'sum(Interstitial%qg)           = ', Interstitial%qg
+    if (associated(Interstitial%qf)) write (0,*) 'sum(Interstitial%qf)           = ', Interstitial%qf
     if (associated(Interstitial%qc)) write (0,*) 'sum(Interstitial%qc)           = ', Interstitial%qc
     write (0,*) 'sum(Interstitial%q_con)        = ', Interstitial%q_con
     write (0,*) 'Interstitial%hydrostatic       = ', Interstitial%hydrostatic

--- a/gfsphysics/CCPP_layer/CCPP_typedefs.meta
+++ b/gfsphysics/CCPP_layer/CCPP_typedefs.meta
@@ -268,6 +268,13 @@
   dimensions = (starting_x_direction_index_domain:ending_x_direction_index_domain,starting_y_direction_index_domain:ending_y_direction_index_domain,1:vertical_dimension_for_fast_physics)
   type = real
   kind = kind_dyn
+[qf]
+  standard_name = mass_weighted_rime_factor_at_Lagrangian_surface
+  long_name = mass weighted rime factor updated by fast physics at Lagrangian surface
+  units = kg kg-1
+  dimensions = (starting_x_direction_index_domain:ending_x_direction_index_domain,starting_y_direction_index_domain:ending_y_direction_index_domain,1:vertical_dimension_for_fast_physics)
+  type = real
+  kind = kind_dyn
 [qc]
   standard_name = cloud_fraction_at_Lagrangian_surface
   long_name = cloud fraction at Lagrangian surface

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -2414,8 +2414,8 @@ module FV3GFS_io_mod
     integer :: i, j, k, idx, nblks, nb, ix, ii, jj
     integer :: is_in, js_in, isc, jsc
     character(len=2) :: xtra
-    real(kind=kind_phys), dimension(nx*ny)      :: var2p
-    real(kind=kind_phys), dimension(nx*ny,levs) :: var3p
+    !real(kind=kind_phys), dimension(nx*ny)      :: var2p
+    !real(kind=kind_phys), dimension(nx*ny,levs) :: var3p
     real(kind=kind_phys), dimension(nx,ny)      :: var2
     real(kind=kind_phys), dimension(nx,ny,levs) :: var3
     real(kind=kind_phys) :: rdt, rtime_int, rtime_intfull, lcnvfac


### PR DESCRIPTION
mimic the practice in HAFS: no UGWP in regional/nesting domain