### PR TITLE
feature/transition-to-capgen-1: update SDF syntax and XML schema, remove DDT dependency in radiation physics, correct units

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = feature/transition-to-capgen-1
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = feature/transition-to-capgen-1
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = feature/transition-to-capgen-1
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = ddt_removal_radiation

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = feature/transition-to-capgen-1
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = improve_log_unit_conversion
+	url = https://github.com/NCAR/ccpp-framework
+	branch = feature/transition-to-capgen-1
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = feature/transition-to-capgen-1
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = ddt_removal_radiation
+	url = https://github.com/NCAR/ccpp-physics
+	branch = feature/transition-to-capgen-1

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = feature/transition-to-capgen-1
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = feature/transition-to-capgen-1
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = improve_log_unit_conversion
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	#url = https://github.com/NCAR/ccpp-physics

--- a/ccpp/suites/suite.xsd
+++ b/ccpp/suites/suite.xsd
@@ -1,48 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xs:schema elementFormDefault="qualified"
-           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="https://dtcenter.org/gmtb/users/ccpp/2018/04/23" 
-           xmlns:namens="https://dtcenter.org/gmtb/users/ccpp/2018/04/23">
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-<!-- definition of function pointer type -->
- <xs:complexType name="functionPointer">
-   <xs:simpleContent>
-     <xs:extension base="xs:string">
-       <xs:attribute name="lib" type="xs:string" use="optional"/>
-       <xs:attribute name="ver" type="xs:string" use="optional"/>
-     </xs:extension>
-   </xs:simpleContent>
-</xs:complexType>
-
-<!-- definition of complex elements -->
+<!-- definition of complex element subcycle -->
 <xs:element name="subcycle">
   <xs:complexType>
     <xs:sequence>
-      <xs:element name="scheme" type="functionPointer" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="scheme" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="loop" type="xs:positiveInteger" use="optional"/>
   </xs:complexType>
 </xs:element>
 
+<!-- definition of complex element group -->
 <xs:element name="group">
   <xs:complexType>
     <xs:choice>
       <xs:element ref="subcycle" minOccurs="1" maxOccurs="unbounded"/>
     </xs:choice>
-    <xs:attribute name="part" type="xs:positiveInteger" use="optional"/>
+    <xs:attribute name="name" type="xs:string"/>
   </xs:complexType>
 </xs:element>
 
+<!-- definition of complex element suite -->
 <xs:element name="suite">
   <xs:complexType>
     <xs:sequence>
-      <xs:element name="init" type="functionPointer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="init" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element ref="group" minOccurs="1" maxOccurs="unbounded"/>
-      <xs:element name="finalize" type="functionPointer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="finalize" type="xs:string" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:string"/>
-    <xs:attribute name="lib" type="xs:string" use="optional"/>
-    <xs:attribute name="ver" type="xs:string" use="optional"/>
+    <xs:attribute name="version" type="xs:positiveInteger" use="optional"/>
   </xs:complexType>
 </xs:element>
 

--- a/ccpp/suites/suite_FV3_CPT_v0.xml
+++ b/ccpp/suites/suite_FV3_CPT_v0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_CPT_v0" lib="ccppphys" ver="4">
+<suite name="FV3_CPT_v0" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_coupled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_coupled" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_coupled" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_couplednsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_couplednsst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_couplednsst" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_couplednsst" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_csawmg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_csawmg" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_csawmg" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_csawmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_csawmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_csawmgshoc" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_csawmgshoc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_fv3wam.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_fv3wam" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_fv3wam" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_gfdlmp" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_noahmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_noahmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp_noahmp" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_gfdlmp_noahmp" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp_regional" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_gfdlmp_regional" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional_c768.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional_c768.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp_regional_c768" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_gfdlmp_regional_c768" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_h2ophys.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_h2ophys.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_h2ophys" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_h2ophys" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_myj.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_myj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_myj" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_myj" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_ntiedtke.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ntiedtke.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_ntiedtke" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_ntiedtke" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_ozphys_2015.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ozphys_2015.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_ozphys_2015" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_ozphys_2015" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_sas.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_sas.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_sas" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_sas" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmf.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_satmedmf" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_satmedmf" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmf_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmf_coupled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_satmedmf_coupled" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_satmedmf_coupled" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmfq.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmfq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_satmedmfq" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_satmedmfq" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_shinhong.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_shinhong.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_shinhong" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_shinhong" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_stretched.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_stretched.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_stretched" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_stretched" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_ysu.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ysu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_ysu" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_2017_ysu" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_cpld_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_cpld_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_cpld_rasmgshoc" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_cpld_rasmgshoc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_cpld_rasmgshocnsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_cpld_rasmgshocnsst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_cpld_rasmgshocnsst" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_cpld_rasmgshocnsst" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_cpldnst_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_cpldnst_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_cpldnst_rasmgshoc" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_cpldnst_rasmgshoc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_rasmgshoc" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_rasmgshoc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_gf.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_gf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_gf" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_gf" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_gf_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_gf_thompson.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_gf_thompson" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_gf_thompson" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_mynn" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_mynn" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_ras.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_ras" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_ras" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_rasmgshoc" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_rasmgshoc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_thompson" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_thompson" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_thompson_mynn" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15_thompson_mynn" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15p2" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_RRTMGP.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2_RRTMGP" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15p2_RRTMGP" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_coupled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2_coupled" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15p2_coupled" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2_no_nsst" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15p2_no_nsst" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15plus.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15plus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15plus" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15plus" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15plusras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15plusras.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15plusras" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15plusras" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16_csawmg" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v16_csawmg" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v16beta" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta_RRTMGP.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta_RRTMGP" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v16beta_RRTMGP" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta_flake.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta_flake" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v16beta_flake" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta_no_nsst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta_no_nsst" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v16beta_no_nsst" version="1">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_SAR.xml
+++ b/ccpp/suites/suite_FV3_GSD_SAR.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_SAR" lib="ccppphys" ver="4">
+<suite name="FV3_GSD_SAR" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_noah" lib="ccppphys" ver="4">
+<suite name="FV3_GSD_noah" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_noah_mynnsfc.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah_mynnsfc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_noah_mynnsfc" lib="ccppphys" ver="4">
+<suite name="FV3_GSD_noah_mynnsfc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_v0" lib="ccppphys" ver="4">
+<suite name="FV3_GSD_v0" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_v0_drag_suite" lib="ccppphys" ver="4">
+<suite name="FV3_GSD_v0_drag_suite" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_v0_mynnsfc.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_mynnsfc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_v0_mynnsfc" lib="ccppphys" ver="4">
+<suite name="FV3_GSD_v0_mynnsfc" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_HAFS_ferhires_update_moist.xml
+++ b/ccpp/suites/suite_FV3_HAFS_ferhires_update_moist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_HAFS_ferhires_update_moist" lib="ccppphys" ver="4">
+<suite name="FV3_HAFS_ferhires_update_moist" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_HRRR" lib="ccppphys" ver="4">
+<suite name="FV3_HRRR" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_RAP" lib="ccppphys" ver="4">
+<suite name="FV3_RAP" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_RRFS_v1beta" lib="ccppphys" ver="4">
+<suite name="FV3_RRFS_v1beta" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -9,7 +9,7 @@ module GFS_typedefs
                                            con_t0c, con_cvap, con_cliq, con_eps, con_epsq, &
                                            con_epsm1, con_ttp, rlapse, con_jcal, con_rhw0, &
                                            con_sbc, con_tice, cimin, con_p0, rhowater,     &
-                                           con_csol, con_epsqs
+                                           con_csol, con_epsqs, con_rocp, con_rog
 
        use module_radsw_parameters,  only: topfsw_type, sfcfsw_type, profsw_type, cmpfsw_type, NBDSW
        use module_radlw_parameters,  only: topflw_type, sfcflw_type, proflw_type, NBDLW
@@ -1105,6 +1105,12 @@ module GFS_typedefs
     integer              :: nkbfshoc        !< the index of upward kinematic buoyancy flux from SHOC in phy_f3d
     integer              :: nahdshoc        !< the index of diffusivity for heat from from SHOC in phy_f3d
     integer              :: nscfshoc        !< the index of subgrid-scale cloud fraction from from SHOC in phy_f3d
+    integer              :: nT2delt         !< the index of air temperature 2 timesteps back for Z-C MP in phy_f3d
+    integer              :: nTdelt          !< the index of air temperature at the previous timestep for Z-C MP in phy_f3d
+    integer              :: nqv2delt        !< the index of specific humidity 2 timesteps back for Z-C MP in phy_f3d
+    integer              :: nqvdelt         !< the index of specific humidity at the previous timestep for Z-C MP in phy_f3d
+    integer              :: nps2delt        !< the index of surface air pressure 2 timesteps back for Z-C MP in phy_f2d
+    integer              :: npsdelt         !< the index of surface air pressure at the previous timestep for Z-C MP in phy_f2d
 #endif
 
 !--- debug flag
@@ -4515,17 +4521,29 @@ module GFS_typedefs
     endif
 
 !--- set up cloud schemes and tracer elements
-    Model%nleffr = -999
-    Model%nieffr = -999
-    Model%nreffr = -999
-    Model%nseffr = -999
-    Model%ngeffr = -999
+    Model%nleffr   = -999
+    Model%nieffr   = -999
+    Model%nreffr   = -999
+    Model%nseffr   = -999
+    Model%ngeffr   = -999
+    Model%nT2delt  = -999
+    Model%nTdelt   = -999
+    Model%nqv2delt = -999
+    Model%nqvdelt  = -999
+    Model%nps2delt = -999
+    Model%npsdelt  = -999
     if (Model%imp_physics == Model%imp_physics_zhao_carr) then
-      Model%npdf3d  = 0
-      Model%num_p3d = 4
-      Model%num_p2d = 3
-      Model%shcnvcw = .false.
-      Model%ncnd    = 1                   ! ncnd is the number of cloud condensate types
+      Model%npdf3d   = 0
+      Model%num_p3d  = 4
+      Model%num_p2d  = 3
+      Model%shcnvcw  = .false.
+      Model%ncnd     = 1                   ! ncnd is the number of cloud condensate types
+      Model%nT2delt  = 1
+      Model%nqv2delt = 2
+      Model%nTdelt   = 3
+      Model%nqvdelt  = 4
+      Model%nps2delt = 1
+      Model%npsdelt  = 2
       if (Model%me == Model%master) print *,' Using Zhao/Carr/Sundqvist Microphysics'
 
     elseif (Model%imp_physics == Model%imp_physics_zhao_carr_pdf) then !Zhao Microphysics with PDF cloud
@@ -4545,9 +4563,9 @@ module GFS_typedefs
       Model%pdfcld  = .false.
       Model%shcnvcw = .false.
       Model%ncnd    = 5
-      Model%nleffr = 1
-      Model%nieffr = 2
-      Model%nseffr = 3
+      Model%nleffr  = 1
+      Model%nieffr  = 2
+      Model%nseffr  = 3
       if (Model%me == Model%master) print *,' Using Ferrier-Aligo MP scheme', &
                                           ' microphysics', &
                                           ' lradar =',Model%lradar
@@ -4572,9 +4590,9 @@ module GFS_typedefs
       Model%pdfcld  = .false.
       Model%shcnvcw = .false.
       Model%ncnd    = 5
-      Model%nleffr = 1
-      Model%nieffr = 2
-      Model%nseffr = 3
+      Model%nleffr  = 1
+      Model%nieffr  = 2
+      Model%nseffr  = 3
       if (Model%me == Model%master) print *,' Using Thompson double moment', &
                                           ' microphysics',' ltaerosol = ',Model%ltaerosol, &
                                           ' ttendlim =',Model%ttendlim, &
@@ -4715,7 +4733,7 @@ module GFS_typedefs
 
 
 !--- BEGIN CODE FROM GLOOPR
-!--- set up parameters for Xu & Randell's cloudiness computation (Radiation)
+!--- set up parameters for Xu & Randall's cloudiness computation (Radiation)
 
     Model%lmfshal  = (Model%shal_cnv .and. Model%imfshalcnv > 0)
 #ifdef CCPP

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -2176,6 +2176,13 @@
   units = none
   dimensions = ()
   type = integer
+[fhzero]
+  standard_name = frequency_for_diagnostic_clearing
+  long_name = frequency for clearing diagnostic fields
+  units = h
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [ldiag3d]
   standard_name = flag_diagnostics_3D
   long_name = flag for 3d diagnostic fields
@@ -2218,6 +2225,42 @@
   units = flag
   dimensions = ()
   type = logical
+[isc]
+  standard_name = starting_x_index_for_this_MPI_rank
+  long_name = starting index in the x direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+[jsc]
+  standard_name = starting_y_index_for_this_MPI_rank
+  long_name = starting index in the y direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+[nx]
+  standard_name = number_of_points_in_x_direction_for_this_MPI_rank
+  long_name = number of points in x direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+[ny]
+  standard_name = number_of_points_in_y_direction_for_this_MPI_rank
+  long_name = number of points in y direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+[cnx]
+  standard_name = number_of_points_in_x_direction_for_this_cubed_sphere_face
+  long_name = number of points in x direction for this cubed sphere face
+  units = count
+  dimensions = ()
+  type = integer
+[cny]
+  standard_name = number_of_points_in_y_direction_for_this_cubed_sphere_face
+  long_name = number of points in y direction for this cubed sphere face
+  units = count
+  dimensions = ()
+  type = integer
 [naux2d]
   standard_name = number_of_2d_auxiliary_arrays
   long_name = number of 2d auxiliary arrays to output (for debugging)
@@ -2335,7 +2378,13 @@
 [nscyc]
   standard_name = number_of_timesteps_between_surface_cycling_calls
   long_name = number of timesteps between surface cycling calls
-  units = 
+  units = count
+  dimensions = ()
+  type = integer
+[nszero]
+  standard_name = number_of_timesteps_between_diagnostic_clearing
+  long_name = number of timesteps between calls to clear diagnostic variables
+  units = count
   dimensions = ()
   type = integer
 [dtp]
@@ -2405,6 +2454,12 @@
 [levrp1]
   standard_name = number_of_vertical_layers_for_radiation_calculations_plus_one
   long_name = number of vertical levels for radiation calculations + 1
+  units = count
+  dimensions = ()
+  type = integer
+[nfxr]
+  standard_name = number_of_radiation_diagnostic_variables
+  long_name = number of variables stored in the fluxr array
   units = count
   dimensions = ()
   type = integer
@@ -2757,6 +2812,12 @@
   dimensions = (2)
   type = real
   kind = kind_phys
+[seed0]
+  standard_name = seed_random_numbers_RAS
+  long_name = random number seed for the RAS scheme
+  units = none
+  dimensions = ()
+  type = integer
 [dlqf]
   standard_name = condensate_fraction_detrained_in_updraft_layers
   long_name = condensate fraction detrained with in a updraft layers
@@ -3033,6 +3094,12 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[lgfdlmprad]
+  standard_name = flag_for_GFDL_microphysics_radiation_interaction
+  long_name = flag for GFDL microphysics-radiation interaction
+  units = flag
+  dimensions = ()
+  type = logical
 [lsm]
   standard_name = flag_for_land_surface_scheme
   long_name = flag for land surface model
@@ -3305,6 +3372,12 @@
   units = flag
   dimensions = ()
   type = logical
+[h2o_phys]
+  standard_name = flag_for_stratospheric_water_vapor_physics
+  long_name = flag for stratospheric water vapor physics
+  units = flag
+  dimensions = ()
+  type = logical
 [shcnvcw]
   standard_name = flag_shallow_convective_cloud
   long_name = flag for shallow convective cloud
@@ -3332,6 +3405,12 @@
 [lheatstrg]
   standard_name = flag_for_canopy_heat_storage
   long_name = flag for canopy heat storage parameterization
+  units = flag
+  dimensions = ()
+  type = logical
+[random_clds]
+  standard_name = flag_for_random_clouds_for_RAS
+  long_name = flag for using random clouds with the RAS scheme
   units = flag
   dimensions = ()
   type = logical
@@ -3708,7 +3787,7 @@
 [rho_h2o]
   standard_name = density_of_fresh_water
   long_name = density of fresh water
-  units = ???
+  units = kg m-3
   dimensions = ()
   type = real
   kind = kind_phys
@@ -4156,6 +4235,42 @@
   units = 
   dimensions = ()
   type = integer
+[nT2delt]
+  standard_name = index_for_air_temperature_two_timesteps_back
+  long_name = the index of air temperature two timesteps back in phy f3d
+  units = 
+  dimensions = ()
+  type = integer
+[nTdelt]
+  standard_name = index_for_air_temperature_at_previous_timestep
+  long_name = the index of air temperature at previous timestep in phy f3d
+  units = 
+  dimensions = ()
+  type = integer
+[nqv2delt]
+  standard_name = index_for_specific_humidity_two_timesteps_back
+  long_name = the index of specific humidity two timesteps back in phy f3d
+  units = 
+  dimensions = ()
+  type = integer
+[nqvdelt]
+  standard_name = index_for_specific_humidity_at_previous_timestep
+  long_name = the index of specific humidity at previous timestep in phy f3d
+  units = 
+  dimensions = ()
+  type = integer
+[nps2delt]
+  standard_name = index_for_surface_air_pressure_two_timesteps_back
+  long_name = the index of surface air pressure two timesteps back in phy f2d
+  units = 
+  dimensions = ()
+  type = integer
+[npsdelt]
+  standard_name = index_for_surface_air_pressure_at_previous_timestep
+  long_name = the index of surface air pressure at previous timestep in phy f2d
+  units = 
+  dimensions = ()
+  type = integer
 [debug]
   standard_name = flag_debug
   long_name = control flag for debug
@@ -4489,14 +4604,20 @@
   long_name = flag for uni_cld
   units = flag
   dimensions = ()
-  type = logical  
+  type = logical
 [lmfshal]
   standard_name = flag_for_lmfshal
   long_name = flag for lmfshal
   units = flag
   dimensions = ()
   type = logical
-
+[lmfdeep2]
+  standard_name = flag_for_scale_aware_mass_flux_convection
+  long_name = flag for some scale-aware mass-flux convection scheme active
+  units = flag
+  dimensions = ()
+  type = logical
+  
 ########################################################################
 [ccpp-table-properties]
   name = GFS_grid_type
@@ -4560,6 +4681,120 @@
   long_name = longitude in degree east
   units = degree_east
   dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[jindx1_o3]
+  standard_name = lower_ozone_interpolation_index
+  long_name = interpolation low index for ozone
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[jindx2_o3]
+  standard_name = upper_ozone_interpolation_index
+  long_name = interpolation high index for ozone
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[ddy_o3]
+  standard_name = ozone_interpolation_weight
+  long_name = interpolation high index for ozone
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[jindx1_h]
+  standard_name = lower_water_vapor_interpolation_index
+  long_name = interpolation low index for stratospheric water vapor
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[jindx2_h]
+  standard_name = upper_water_vapor_interpolation_index
+  long_name = interpolation high index for stratospheric water vapor
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[ddy_h]
+  standard_name = water_vapor_interpolation_weight
+  long_name = interpolation high index for stratospheric water vapor
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[jindx1_aer]
+  standard_name = lower_aerosol_y_interpolation_index
+  long_name = interpolation low index for prescribed aerosols in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[jindx2_aer]
+  standard_name = upper_aerosol_y_interpolation_index
+  long_name = interpolation high index for prescribed aerosols in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[ddy_aer]
+  standard_name = aerosol_y_interpolation_weight
+  long_name = interpolation high index for prescribed aerosols in the y direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[iindx1_aer]
+  standard_name = lower_aerosol_x_interpolation_index
+  long_name = interpolation low index for prescribed aerosols in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[iindx2_aer]
+  standard_name = upper_aerosol_x_interpolation_index
+  long_name = interpolation high index for prescribed aerosols in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[ddx_aer]
+  standard_name = aerosol_x_interpolation_weight
+  long_name = interpolation high index for prescribed aerosols in the x direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[jindx1_ci]
+  standard_name = lower_cloud_nuclei_y_interpolation_index
+  long_name = interpolation low index for ice and cloud condensation nuclei in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[jindx2_ci]
+  standard_name = upper_cloud_nuclei_y_interpolation_index
+  long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[ddy_ci]
+  standard_name = cloud_nuclei_y_interpolation_weight
+  long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[iindx1_ci]
+  standard_name = lower_cloud_nuclei_x_interpolation_index
+  long_name = interpolation low index for ice and cloud condensation nuclei in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[iindx2_ci]
+  standard_name = upper_cloud_nuclei_x_interpolation_index
+  long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+[ddx_ci]
+  standard_name = cloud_nuclei_x_interpolation_weight
+  long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
+  units = none
+  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
 
@@ -4700,16 +4935,16 @@
   type = real
   kind = kind_phys
   active = (number_of_cloud_types_CS > 0 .and. flag_for_Chikira_Sugiyama_deep_convection)
-[phy_f2d(:,1)]
-  standard_name = surface_air_pressure_two_time_steps_back
-  long_name = surface air pressure two time steps back
+[phy_f2d(:,index_for_surface_air_pressure_two_timesteps_back)]
+  standard_name = surface_air_pressure_two_timesteps_back
+  long_name = surface air pressure two timesteps back
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[phy_f2d(:,2)]
-  standard_name = surface_air_pressure_at_previous_time_step
-  long_name = surface air pressure at previous time step
+[phy_f2d(:,index_for_surface_air_pressure_at_previous_timestep)]
+  standard_name = surface_air_pressure_at_previous_timestep
+  long_name = surface air pressure at previous timestep
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
@@ -4721,30 +4956,30 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[phy_f3d(:,:,1)]
-  standard_name = air_temperature_two_time_steps_back
-  long_name = air temperature two time steps back
+[phy_f3d(:,:,index_for_air_temperature_two_timesteps_back)]
+  standard_name = air_temperature_two_timesteps_back
+  long_name = air temperature two timesteps back
   units = K
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
-[phy_f3d(:,:,2)]
-  standard_name = water_vapor_specific_humidity_two_time_steps_back
-  long_name = water vapor specific humidity two time steps back
+[phy_f3d(:,:,index_for_specific_humidity_two_timesteps_back)]
+  standard_name = water_vapor_specific_humidity_two_timesteps_back
+  long_name = water vapor specific humidity two timesteps back
   units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
-[phy_f3d(:,:,3)]
-  standard_name = air_temperature_at_previous_time_step
-  long_name = air temperature at previous time step
+[phy_f3d(:,:,index_for_air_temperature_at_previous_timestep)]
+  standard_name = air_temperature_at_previous_timestep
+  long_name = air temperature at previous timestep
   units = K
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
-[phy_f3d(:,:,4)]
-  standard_name = water_vapor_specific_humidity_at_previous_time_step
-  long_name = water vapor specific humidity at previous time step
+[phy_f3d(:,:,index_for_specific_humidity_at_previous_timestep)]
+  standard_name = water_vapor_specific_humidity_at_previous_timestep
+  long_name = water vapor specific humidity at previous timestep
   units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
@@ -5174,6 +5409,13 @@
 [ccpp-arg-table]
   name = GFS_diag_type
   type = ddt
+[fluxr]
+  standard_name = cumulative_radiation_diagnostic
+  long_name = time-accumulated 2D radiation-related diagnostic fields
+  units = various
+  dimensions = (horizontal_dimension,number_of_radiation_diagnostic_variables)
+  type = real
+  kind = kind_phys
 [topfsw]
   standard_name = sw_fluxes_top_atmosphere
   long_name = sw radiation fluxes at toa
@@ -5911,6 +6153,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,2)]
   standard_name = cumulative_change_in_x_wind_due_to_orographic_gravity_wave_drag
   long_name = cumulative change in x wind due to orographic gravity wave drag
@@ -5918,6 +6161,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,3)]
   standard_name = cumulative_change_in_x_wind_due_to_deep_convection
   long_name = cumulative change in x wind due to deep convection
@@ -5925,6 +6169,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,4)]
   standard_name = cumulative_change_in_x_wind_due_to_convective_gravity_wave_drag
   long_name = cumulative change in x wind due to convective gravity wave drag
@@ -5932,6 +6177,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,5)]
   standard_name = cumulative_change_in_x_wind_due_to_rayleigh_damping
   long_name = cumulative change in x wind due to Rayleigh damping
@@ -5939,6 +6185,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,6)]
   standard_name = cumulative_change_in_x_wind_due_to_shallow_convection
   long_name = cumulative change in x wind due to shallow convection
@@ -5946,6 +6193,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,7)]
   standard_name = cumulative_change_in_x_wind_due_to_physics
   long_name = cumulative change in x wind due to physics
@@ -5953,6 +6201,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [du3dt(:,:,8)]
   standard_name = cumulative_change_in_x_wind_due_to_non_physics_processes
   long_name = cumulative change in x wind due to non-physics processes
@@ -5968,6 +6217,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dv3dt(:,:,2)]
   standard_name = cumulative_change_in_y_wind_due_to_orographic_gravity_wave_drag
   long_name = cumulative change in y wind due to orographic gravity wave drag
@@ -5975,6 +6225,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dv3dt(:,:,3)]
   standard_name = cumulative_change_in_y_wind_due_to_deep_convection
   long_name = cumulative change in y wind due to deep convection
@@ -5982,6 +6233,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dv3dt(:,:,4)]
   standard_name = cumulative_change_in_y_wind_due_to_convective_gravity_wave_drag
   long_name = cumulative change in y wind due to convective gravity wave drag
@@ -5996,6 +6248,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dv3dt(:,:,6)]
   standard_name = cumulative_change_in_y_wind_due_to_shallow_convection
   long_name = cumulative change in y wind due to shallow convection
@@ -6003,6 +6256,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dv3dt(:,:,7)]
   standard_name = cumulative_change_in_y_wind_due_to_physics
   long_name = cumulative change in y wind due to physics
@@ -6010,6 +6264,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dv3dt(:,:,8)]
   standard_name = cumulative_change_in_y_wind_due_to_non_physics_processes
   long_name = cumulative change in y wind due to non-physics processes
@@ -6025,6 +6280,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,2)]
   standard_name = cumulative_change_in_temperature_due_to_shortwave_radiation
   long_name = cumulative change in temperature due to shortwave radiation
@@ -6032,6 +6288,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,3)]
   standard_name = cumulative_change_in_temperature_due_to_PBL
   long_name = cumulative change in temperature due to PBL
@@ -6039,6 +6296,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,4)]
   standard_name = cumulative_change_in_temperature_due_to_deep_convection
   long_name = cumulative change in temperature due to deep convection
@@ -6046,6 +6304,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,5)]
   standard_name = cumulative_change_in_temperature_due_to_shallow_convection
   long_name = cumulative change in temperature due to shallow convection
@@ -6053,6 +6312,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,6)]
   standard_name = cumulative_change_in_temperature_due_to_microphysics
   long_name = cumulative change in temperature due to microphysics
@@ -6060,6 +6320,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,7)]
   standard_name = cumulative_change_in_temperature_due_to_orographic_gravity_wave_drag
   long_name = cumulative change in temperature due to orographic gravity wave drag
@@ -6067,6 +6328,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,8)]
   standard_name = cumulative_change_in_temperature_due_to_rayleigh_damping
   long_name = cumulative change in temperature due to Rayleigh damping
@@ -6074,6 +6336,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,9)]
   standard_name = cumulative_change_in_temperature_due_to_convective_gravity_wave_drag
   long_name = cumulative change in temperature due to convective gravity wave drag
@@ -6081,6 +6344,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,10)]
   standard_name = cumulative_change_in_temperature_due_to_physics
   long_name = cumulative change in temperature due to physics
@@ -6088,6 +6352,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D)
 [dt3dt(:,:,11)]
   standard_name = cumulative_change_in_temperature_due_to_non_physics_processes
   long_name = cumulative change in temperature due to non-physics processed
@@ -6103,6 +6368,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,2)]
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_deep_convection
   long_name = cumulative change in water vapor specific humidity due to deep convection
@@ -6110,6 +6376,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,3)]
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_shallow_convection
   long_name = cumulative change in water vapor specific humidity due to shallow convection
@@ -6117,6 +6384,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,4)]
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_microphysics
   long_name = cumulative change in water vapor specific humidity due to microphysics
@@ -6124,6 +6392,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,5)]
   standard_name = cumulative_change_in_ozone_mixing_ratio_due_to_PBL
   long_name = cumulative change in ozone mixing ratio due to PBL
@@ -6131,6 +6400,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,6)]
   standard_name = cumulative_change_in_ozone_concentration_due_to_production_and_loss_rate
   long_name = cumulative change in ozone concentration due to production and loss rate
@@ -6138,6 +6408,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,7)]
   standard_name = cumulative_change_in_ozone_concentration_due_to_ozone_mixing_ratio
   long_name = cumulative change in ozone concentration due to ozone mixing ratio
@@ -6145,6 +6416,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,8)]
   standard_name = cumulative_change_in_ozone_concentration_due_to_temperature
   long_name = cumulative change in ozone concentration due to temperature
@@ -6152,6 +6424,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,9)]
   standard_name = cumulative_change_in_ozone_concentration_due_to_overhead_ozone_column
   long_name = cumulative change in ozone concentration due to overhead ozone column
@@ -6159,6 +6432,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,10)]
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_physics
   long_name = cumulative change in water vapor specific humidity due to physics
@@ -6166,6 +6440,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,11)]
   standard_name = cumulative_change_in_ozone_concentration_due_to_physics
   long_name = cumulative change in ozone concentration due to physics
@@ -6173,6 +6448,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,12)]
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_non_physics_processes
   long_name = cumulative change in water vapor specific humidity due to non-physics processes
@@ -6180,6 +6456,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
 [dq3dt(:,:,13)]
   standard_name = cumulative_change_in_ozone_concentration_due_to_non_physics_processes
   long_name = cumulative change in ozone_concentration due to non-physics processes
@@ -9807,6 +10084,20 @@
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
   long_name = (rd/rv) - 1
   units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[con_rocp]
+  standard_name = ratio_of_gas_constant_dry_air_to_specific_heat_of_dry_air_at_constant_pressure
+  long_name = (rd/cp)
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[con_rog]
+  standard_name = ratio_of_gas_constant_dry_air_to_gravitational_acceleration
+  long_name = (rd/g)
+  units = J s2 K-1 kg-1 m-1
   dimensions = ()
   type = real
   kind = kind_phys

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -2959,7 +2959,7 @@
 [effr_in]
   standard_name = flag_for_cloud_effective_radii
   long_name = flag for cloud effective radii calculations in GFDL microphysics
-  units = 
+  units = flag
   dimensions = ()
   type = logical
 [microp_uniform]
@@ -4196,43 +4196,43 @@
 [ncnvw]
   standard_name = index_for_convective_cloud_water_mixing_ratio_in_phy_f3d
   long_name = the index of convective cloud water mixing ratio in phy f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [ncnvc]
   standard_name = index_for_convective_cloud_cover_in_phy_f3d
   long_name = the index of convective cloud cover in phy f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [nleffr]
   standard_name = index_for_cloud_liquid_water_effective_radius
   long_name = the index of cloud liquid water effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [nieffr]
   standard_name = index_for_ice_effective_radius
   long_name = the index of ice effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [nreffr]
   standard_name = index_for_rain_effective_radius
   long_name = the index of rain effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [nseffr]
   standard_name = index_for_snow_effective_radius
   long_name = the index of snow effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [ngeffr]
   standard_name = index_for_graupel_effective_radius
   long_name = the index of graupel effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [nT2delt]
@@ -4280,7 +4280,7 @@
 [ipt]
   standard_name = index_for_diagnostic_printout
   long_name = horizontal index for point used for diagnostic printout
-  units = 
+  units = index
   dimensions = ()
   type = integer
 [lprnt]
@@ -4687,114 +4687,114 @@
   standard_name = lower_ozone_interpolation_index
   long_name = interpolation low index for ozone
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [jindx2_o3]
   standard_name = upper_ozone_interpolation_index
   long_name = interpolation high index for ozone
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [ddy_o3]
   standard_name = ozone_interpolation_weight
   long_name = interpolation high index for ozone
   units = none
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [jindx1_h]
   standard_name = lower_water_vapor_interpolation_index
   long_name = interpolation low index for stratospheric water vapor
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [jindx2_h]
   standard_name = upper_water_vapor_interpolation_index
   long_name = interpolation high index for stratospheric water vapor
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [ddy_h]
   standard_name = water_vapor_interpolation_weight
   long_name = interpolation high index for stratospheric water vapor
   units = none
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [jindx1_aer]
   standard_name = lower_aerosol_y_interpolation_index
   long_name = interpolation low index for prescribed aerosols in the y direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [jindx2_aer]
   standard_name = upper_aerosol_y_interpolation_index
   long_name = interpolation high index for prescribed aerosols in the y direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [ddy_aer]
   standard_name = aerosol_y_interpolation_weight
   long_name = interpolation high index for prescribed aerosols in the y direction
   units = none
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [iindx1_aer]
   standard_name = lower_aerosol_x_interpolation_index
   long_name = interpolation low index for prescribed aerosols in the x direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [iindx2_aer]
   standard_name = upper_aerosol_x_interpolation_index
   long_name = interpolation high index for prescribed aerosols in the x direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [ddx_aer]
   standard_name = aerosol_x_interpolation_weight
   long_name = interpolation high index for prescribed aerosols in the x direction
   units = none
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [jindx1_ci]
   standard_name = lower_cloud_nuclei_y_interpolation_index
   long_name = interpolation low index for ice and cloud condensation nuclei in the y direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [jindx2_ci]
   standard_name = upper_cloud_nuclei_y_interpolation_index
   long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [ddy_ci]
   standard_name = cloud_nuclei_y_interpolation_weight
   long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
   units = none
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [iindx1_ci]
   standard_name = lower_cloud_nuclei_x_interpolation_index
   long_name = interpolation low index for ice and cloud condensation nuclei in the x direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [iindx2_ci]
   standard_name = upper_cloud_nuclei_x_interpolation_index
   long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
   units = index
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = integer
 [ddx_ci]
   standard_name = cloud_nuclei_x_interpolation_weight
   long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
   units = none
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 
@@ -4843,23 +4843,23 @@
   type = real
   kind = kind_phys
 [in_nm]
-  standard_name = in_number_concentration
-  long_name = IN number concentration
-  units = kg-1?
+  standard_name = ice_nucleation_number
+  long_name = ice nucleation number in MG MP
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
 [ccn_nm]
-  standard_name = ccn_number_concentration
-  long_name = CCN number concentration
-  units = kg-1?
+  standard_name = tendency_of_ccn_activated_number
+  long_name = tendency of ccn activated number
+  units = kg-1 s-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
 [aer_nm]
   standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
   long_name = GOCART aerosol climatology number concentration
-  units = kg-1?
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys
@@ -5413,7 +5413,7 @@
   standard_name = cumulative_radiation_diagnostic
   long_name = time-accumulated 2D radiation-related diagnostic fields
   units = various
-  dimensions = (horizontal_dimension,number_of_radiation_diagnostic_variables)
+  dimensions = (horizontal_loop_extent,number_of_radiation_diagnostic_variables)
   type = real
   kind = kind_phys
 [topfsw]
@@ -6510,21 +6510,21 @@
 [upd_mf]
   standard_name = cumulative_atmosphere_updraft_convective_mass_flux
   long_name = cumulative updraft mass flux
-  units = Pa
+  units = kg m-1 s-2
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
 [dwn_mf]
   standard_name = cumulative_atmosphere_downdraft_convective_mass_flux
   long_name = cumulative downdraft mass flux
-  units = Pa
+  units = kg m-1 s-2
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
 [det_mf]
   standard_name = cumulative_atmosphere_detrainment_convective_mass_flux
   long_name = cumulative detrainment mass flux
-  units = Pa
+  units = kg m-1 s-2
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -6539,7 +6539,7 @@
   standard_name = instantaneous_3d_cloud_fraction
   long_name = instantaneous 3D cloud fraction for all MPs
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [ndust]
@@ -7179,63 +7179,63 @@
   standard_name = total_cloud_fraction
   long_name = layer total cloud fraction
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,2)]
   standard_name = cloud_liquid_water_path
   long_name = layer cloud liquid water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,3)]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,4)]
   standard_name = cloud_ice_water_path
   long_name = layer cloud ice water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,5)]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,6)]
   standard_name = cloud_rain_water_path
   long_name = cloud rain water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,7)]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain drop
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,8)]
   standard_name = cloud_snow_water_path
   long_name = cloud snow water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clouds(:,:,9)]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow flake
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [clw]


### PR DESCRIPTION
## Description

This PR contains

- support for removal of GFS DDTs from CCPP physics, https://github.com/NOAA-EMC/fv3atm/pull/162
- correct metadata name/unit/dimension, https://github.com/NOAA-EMC/fv3atm/pull/170

updated with the latest code in feature/transition-to-capgen-1. Additional changes:

- update XML schema and syntax for all suite definition files; all SDFs validate against `suite.xsd` using `xmllint`

## Testing

See https://github.com/NCAR/ufs-weather-model/pull/65

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/506
https://github.com/NCAR/ccpp-framework/pull/327
https://github.com/NCAR/fv3atm/pull/64
https://github.com/NCAR/ufs-weather-model/pull/65