### PR TITLE
Bugfix and optimization of prognostic closure for the P8 physics suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+#  url = https://github.com/NCAR/ccpp-physics
+#  branch = main
+  url = https://github.com/lisa-bengtsson/ccpp-physics
+  branch = prog_bugfix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/NCAR/ccpp-physics
-#  branch = main
-  url = https://github.com/lisa-bengtsson/ccpp-physics
-  branch = prog_bugfix
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
@lisa-bengtsson Can you close  [NOAA-EMC #592](https://github.com/NOAA-EMC/fv3atm/pull/582) in favor of this PR?

This PR corrects a bug when using the prognostic closure (progsigma = true) to compute the q-tendency due to microphysics even if the diagnostic flags are false. It also optimizes the cloudbase massflux value for shallow and deep convection to work with the overall P8 physics suite.

New baselines are needed for the test: control_c384_progsigma

This update does not change the results in the control tests.

###issues
It addresses the issue: https://github.com/NCAR/ccpp-physics/issues/960

###dependencies
https://github.com/NCAR/ccpp-physics/pull/967
